### PR TITLE
Decrease node requirement to =>0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     },
     "main": "./lib/targz",
     "engines": {
-        "node": "0.8.x"
+        "node": ">=0.6.0"
     },
     "scripts": { 
         "prepublish": "cake build"


### PR DESCRIPTION
I needed to use tar.gz as an easy drop in to create compressed files of a directory. None of the code in this lib, nor do the dependencies need 0.8.0. Since I was running 0.6.0, I needed  to downgrade the node engine requirement.

Consider making this change to those of us still using 0.6.x can use tar.gz. Thanks.
