### PR TITLE
Better error handling during extraction

### DIFF
--- a/lib/targz.js
+++ b/lib/targz.js
@@ -57,16 +57,28 @@ TarGz = (function() {
     return this;
   };
 
-  TarGz.prototype.extract = function(source, destination, callback) {
+  TarGz.prototype.extract = function(source, destination, callback, errback) {
     var self;
     self = this;
+    if (!errback) {
+      errback = (function(err) {
+        return console.log(err);
+      });
+    }
     process.nextTick(function() {
-      return fstream.Reader({
+      var gzstream, stream, tstream;
+      stream = fstream.Reader({
         path: source,
         type: 'File'
-      }).pipe(zlib.createGunzip()).pipe(tar.Extract({
+      });
+      stream.on('error', errback);
+      gzstream = stream.pipe(zlib.createGunzip());
+      gzstream.on('error', errback);
+      tstream = gzstream.pipe(tar.Extract({
         path: destination
-      })).on('end', function() {
+      }));
+      tstream.on('error', errback);
+      return tstream.on('end', function() {
         if (typeof callback === 'function') {
           return callback(null);
         }


### PR DESCRIPTION
`extract` failed to handle errors along the extraction pipeline, so any errors that did occur would crash the process. This pull request adds an `errback` handler to `extract` so that any such errors can be handled gracefully. This ties in with an open issue (#2)
