### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,5 @@
     "bugs": {
         "url": "http://github.com/cranic/node-tar.gz/issues"
     },
-    "license" : "MIT <http://opensource.org/licenses/MIT>"
+    "license" : "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/