### PR TITLE
Possible fix for "delayed" archive extraction issue

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,7 @@
+tar.gz contributors (sorted alphabeticaly)
+============================================
+
+* **[Alan Hoffmeister](https://github.com/alanhoff)**
+
+  * Developed the first version
+  * Released version v1.00

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,7 @@ tar.gz contributors (sorted alphabeticaly)
 
   * Developed the first version
   * Released version v1.00
+
+* **[Frederick John Milens III](https://github.com/fjmilens3)**
+
+  * Fix for "delayed" archive extraction issue

--- a/index.js
+++ b/index.js
@@ -56,8 +56,13 @@ TarGz.prototype.createWriteStream = function(directory) {
     strip: this._options.tar.strip || 0
   });
 
-  this._bubble(stream1, stream2);
+  this._bubble(stream2, stream1);
   stream1.pipe(stream2);
+
+  // Monkey patch stream1's .on() so stream2 actually handles events
+  stream1.on = function(event, listener) {
+    stream2.on(event, listener);
+  };
 
   return stream1;
 };

--- a/test/compression-test.js
+++ b/test/compression-test.js
@@ -23,12 +23,10 @@ describe('General compression test', function() {
       var write = targz().createWriteStream(dir);
 
       write.on('close', function() {
-        setTimeout(function() {
-          expect(utils.equalFiles(
-            __dirname + '/fixtures/uncompressed/lorem.txt',
-            dir + '/uncompressed/lorem.txt')).to.be.equal(true);
-          done();
-        }, 100);
+        expect(utils.equalFiles(
+          __dirname + '/fixtures/uncompressed/lorem.txt',
+          dir + '/uncompressed/lorem.txt')).to.be.equal(true);
+        done();
       });
 
       read.pipe(write);

--- a/test/compression-test.js
+++ b/test/compression-test.js
@@ -23,6 +23,7 @@ describe('General compression test', function() {
       var write = targz().createWriteStream(dir);
 
       write.on('close', function() {
+        expect(fs.readdirSync(dir + '/uncompressed')).to.have.length(2);
         expect(utils.equalFiles(
           __dirname + '/fixtures/uncompressed/lorem.txt',
           dir + '/uncompressed/lorem.txt')).to.be.equal(true);


### PR DESCRIPTION
This is rather ugly, but the basic idea is that the underlying cause of #20 is that we're responding to events on stream1 when we're in general more interested in events on stream2 (particularly once event bubbling is correctly set up).  In particular, when stream1 emits a `finish` event, this only indicates that the archive has been decompressed, not that the decompressed output tar has been successfully extracted. 

To fix this without changing the method signatures (which constitute part of the public API) this is a rather hackish workaround that replaces the `.on()` method of stream1 with a one-line function that delegates to stream2's `.on()` implementation. This appears to both solve my particular issue and not break the test suite any more than it was initially running into, but I am concerned about the long-term impact on downstream projects now receiving a stream that behaves in an idiosyncratic way.

Note that there is an 'incorrect header check' mentioned in the automated test run, but I also ran into this prior to commencing work on the code, as well as appearing in the CI output for the original project in Travis (Build Job 16.1). At the very least, the test suite seems to be behaving as it did prior to this fix.