### PR TITLE
Revert callback changes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,8 +5,3 @@ tar.gz contributors (sorted alphabeticaly)
 
   * Developed the first version
   * Released version v1.00
-
-* **[Frederick John Milens III](https://github.com/fjmilens3)**
-
-  * Fix for "delayed" archive extraction issue
-

--- a/index.js
+++ b/index.js
@@ -56,13 +56,8 @@ TarGz.prototype.createWriteStream = function(directory) {
     strip: this._options.tar.strip || 0
   });
 
-  this._bubble(stream2, stream1);
+  this._bubble(stream1, stream2);
   stream1.pipe(stream2);
-
-  // Monkey patch stream1's .on() so stream2 actually handles events
-  stream1.on = function(event, listener) {
-    stream2.on(event, listener);
-  };
 
   return stream1;
 };

--- a/test/compression-test.js
+++ b/test/compression-test.js
@@ -23,11 +23,12 @@ describe('General compression test', function() {
       var write = targz().createWriteStream(dir);
 
       write.on('close', function() {
-        expect(fs.readdirSync(dir + '/uncompressed')).to.have.length(2);
-        expect(utils.equalFiles(
-          __dirname + '/fixtures/uncompressed/lorem.txt',
-          dir + '/uncompressed/lorem.txt')).to.be.equal(true);
-        done();
+        setTimeout(function() {
+          expect(utils.equalFiles(
+            __dirname + '/fixtures/uncompressed/lorem.txt',
+            dir + '/uncompressed/lorem.txt')).to.be.equal(true);
+          done();
+        }, 100);
       });
 
       read.pipe(write);


### PR DESCRIPTION
This reverts commit 431d6b149cb49a4873cb5749366a90f58ee33f6a, hopefully resolving issues described in #29 and #35. My original PR was the only change in the release which introduced the regression, so backing the changes out seems the best course of action in the absence of more reproducible test cases.

This does mean that the original issues reported in #20 and related issues will likely reappear. However, the overall impact of those issues seems to be more limited among the userbase than the new issues introduced by the "fix" I submitted. Basically, we're better off with how it was broken before than how it's broken now.