### PR TITLE
Allow passing readerFilter from tar options into Reader options

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,11 @@ var TarGz = module.exports = function(zoptions, toptions) {
 TarGz.prototype.createReadStream = function(directory) {
 
   // Create all needed streams
-  var stream1 = fstream.Reader(directory);
+  // passing readerFilter from tar option, if any
+  var stream1 = fstream.Reader({
+      path: directory,
+      filter: (this._options.tar && this._options.tar.readerFilter) ? this._options.tar.readerFilter : null
+  });
   var stream2 = tar.Pack(this._options.tar);
   var stream3 = zlib.createGzip(this._options.zlib);
 


### PR DESCRIPTION
In order to allow fast filtering when picking up entries at the Reader end of the pipeline, we need a mechanism to supply fstream.Reader with a filter function. This PR includes a proposed change for that. 